### PR TITLE
use native-or-bluebird

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.11"
 services:
   - redis-server

--- a/modules/utils/Promise.js
+++ b/modules/utils/Promise.js
@@ -1,1 +1,1 @@
-module.exports = require('bluebird');
+module.exports = require('native-or-bluebird');

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "url": "git://github.com/mjackson/then-redis.git"
   },
   "dependencies": {
-    "bluebird": "^2.3.11",
+    "native-or-bluebird": "1",
     "redis": "^0.12.1"
   },
   "devDependencies": {
+    "bluebird": "^2.4.3",
     "expect": "^1.1.0",
     "jshint": "^2.5.10",
     "mocha": "^2.0.1"


### PR DESCRIPTION
so, when I use node@0.11.13+, I can use `native promise`, no need `bluebird`
