### PR TITLE
added .end() to forcibly close connection

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -123,6 +123,10 @@ Client.prototype.send = function (command, args) {
   });
 };
 
+Client.prototype.end = function () {
+  return this._redisClient.end.apply(this._redisClient, arguments);
+};
+
 var slice = Array.prototype.slice;
 
 Object.defineProperties(Client.prototype, {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ db.send('mset', [ 'a', 'one', 'b', 'two' ]);
 
 \* `INFO`, `MGET`, `MSET`, `MSETNX`, `HMSET`, `HGETALL`, `LPUSH`, and `RPUSH` optionally accept/return JavaScript objects for convenience in dealing with Redis' multi-key and hash APIs
 
+### Forcibly closing the connection
+
+```js
+db.end()
+```
+
 ### Compatibility
 
 For best results, it is recommended that you use Redis 2.6 or above.


### PR DESCRIPTION
I was having problems with my Node process not exiting, and realised that I used to call `client.end()` in the original non-promise redis API.