### PR TITLE
Atomic multi + exec

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -180,6 +180,30 @@ Object.defineProperties(Client.prototype, {
 
 });
 
+Client.prototype.multi = function () {
+  var client = this._redisClient;
+
+  var multi = this._redisClient.multi();
+  var originalExec = multi.exec;
+  multi.exec = function () {
+    var self = this;
+
+    return new Promise(function (resolve, reject) {
+      originalExec.call(self, function (error, result) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  };
+
+  multi.EXEC = multi.exec;
+
+  return multi;
+};
+
 // Optionally accept an array as the first argument to LPUSH and RPUSH after the key.
 [ 'lpush', 'rpush' ].forEach(function (command) {
   Object.defineProperty(Client.prototype, command, d(function (key, array) {

--- a/Client.js
+++ b/Client.js
@@ -180,16 +180,12 @@ Object.defineProperties(Client.prototype, {
 
 });
 
-Client.prototype.multi = function () {
-  var client = this._redisClient;
-
-  var multi = this._redisClient.multi();
-  var originalExec = multi.exec;
-  multi.exec = function () {
-    var self = this;
-
+Client.prototype.exec = function (multiFn) {
+  if (multiFn) {
+    var multi = this._redisClient.multi();
+    multiFn(multi);
     return new Promise(function (resolve, reject) {
-      originalExec.call(self, function (error, result) {
+      multi.exec(function (error, result) {
         if (error) {
           reject(error);
         } else {
@@ -197,11 +193,9 @@ Client.prototype.multi = function () {
         }
       });
     });
-  };
-
-  multi.EXEC = multi.exec;
-
-  return multi;
+  } else {
+    return this.send('exec');
+  }
 };
 
 // Optionally accept an array as the first argument to LPUSH and RPUSH after the key.

--- a/tests/transactions-test.js
+++ b/tests/transactions-test.js
@@ -1,14 +1,15 @@
 var assert = require('assert');
 var expect = require('expect');
 var db = require('./db');
+var Promise = require('bluebird');
 
 describe('transactions', function () {
   describe('when there is no error inside a transaction', function () {
     it('executes the transaction successfully', function () {
-      db.multi();
-      db.incr('a');
-      db.incr('b');
-      return db.exec().then(function (reply) {
+      var multi = db.multi();
+      multi.incr('a');
+      multi.incr('b');
+      return multi.exec().then(function (reply) {
         expect(reply).toEqual([ 1, 1 ]);
       });
     });
@@ -16,24 +17,73 @@ describe('transactions', function () {
 
   describe('when there is an error executing the transaction', function () {
     it('returns the error', function () {
-      db.multi();
-      db.set('a', 'hello');
-      db.incr('a');
-      return db.exec().then(function (reply) {
+      var multi = db.multi();
+      multi.set('a', 'hello');
+      multi.incr('a');
+      return multi.exec().then(function (reply) {
         expect(reply.length).toEqual(2);
         expect(reply[1]).toEqual('ERR value is not an integer or out of range');
       });
     });
   });
 
-  describe('when there is an error enqueueing the transaction', function () {
+  describe('transactions are atomic', function () {
     it('throws the error', function () {
-      db.multi();
-      return db.send('unknown-command').then(function () {
-        assert(false, 'successfully queued non-existent command');
-      }, function (error) {
-        assert(error);
-        return db.discard();
+      var log = [];
+
+      function wait(n) {
+        return new Promise(function (fulfil) {
+          setTimeout(fulfil, n);
+        });
+      }
+
+      function transaction1() {
+        var multi = db.multi();
+
+        return wait(10).then(function () {
+          multi.set('a', 'x');
+          return wait(10);
+        }).then(function () {
+          multi.set('b', 'y');
+          return wait(10);
+        }).then(function () {
+          multi.set('c', 'z');
+          return wait(10);
+        }).then(function () {
+          return multi.exec();
+        });
+      }
+
+      function transaction2() {
+        var multi = db.multi();
+
+        return wait(10).then(function () {
+          multi.set('a', 'a');
+          return wait(10);
+        }).then(function () {
+          multi.set('b', 'b');
+          return wait(10);
+        }).then(function () {
+          return multi.exec();
+        });
+      }
+
+      function logValues() {
+        return db.mget('a', 'b', 'c').then(function (results) {
+          log.push(results);
+          if (results[2] !== 'z') {
+            return logValues();
+          }
+        });
+      }
+
+      return Promise.all([transaction1(), transaction2(), logValues()]).then(function (results) {
+        var momentsWhenAAndBAreDifferent = log.filter(function (entry) {
+          return entry[0] && entry[1] && entry[0] === entry[1];
+        });
+        expect(momentsWhenAAndBAreDifferent).toEqual([]);
+        expect(results[0]).toEqual(['OK', 'OK', 'OK']);
+        expect(results[1]).toEqual(['OK', 'OK']);
       });
     });
   });

--- a/tests/transactions-test.js
+++ b/tests/transactions-test.js
@@ -4,86 +4,109 @@ var db = require('./db');
 var Promise = require('bluebird');
 
 describe('transactions', function () {
-  describe('when there is no error inside a transaction', function () {
-    it('executes the transaction successfully', function () {
-      var multi = db.multi();
-      multi.incr('a');
-      multi.incr('b');
-      return multi.exec().then(function (reply) {
-        expect(reply).toEqual([ 1, 1 ]);
+  describe('multi', function () {
+    describe('when there is no error inside a transaction', function () {
+      it('executes the transaction successfully', function () {
+        db.multi();
+        db.incr('a');
+        db.incr('b');
+        return db.exec().then(function (reply) {
+          expect(reply).toEqual([ 1, 1 ]);
+        });
+      });
+    });
+
+    describe('when there is an error executing the transaction', function () {
+      it('returns the error', function () {
+        db.multi();
+        db.set('a', 'hello');
+        db.incr('a');
+        return db.exec().then(function (reply) {
+          expect(reply.length).toEqual(2);
+          expect(reply[1]).toEqual('ERR value is not an integer or out of range');
+        });
+      });
+    });
+
+    describe('when there is an error enqueueing the transaction', function () {
+      it('throws the error', function () {
+        db.multi();
+        return db.send('unknown-command').then(function () {
+          assert(false, 'successfully queued non-existent command');
+        }, function (error) {
+          assert(error);
+          return db.discard();
+        });
       });
     });
   });
 
-  describe('when there is an error executing the transaction', function () {
-    it('returns the error', function () {
-      var multi = db.multi();
-      multi.set('a', 'hello');
-      multi.incr('a');
-      return multi.exec().then(function (reply) {
-        expect(reply.length).toEqual(2);
-        expect(reply[1]).toEqual('ERR value is not an integer or out of range');
+  describe('exec', function () {
+    describe('when there is no error inside a transaction', function () {
+      it('executes the transaction successfully', function () {
+        return db.exec(function (multi) {
+          multi.incr('a');
+          multi.incr('b');
+        }).then(function (reply) {
+          expect(reply).toEqual([ 1, 1 ]);
+        });
       });
     });
-  });
 
-  describe('transactions are atomic', function () {
-    it('throws the error', function () {
-      var log = [];
-
-      function wait(n) {
-        return new Promise(function (fulfil) {
-          setTimeout(fulfil, n);
+    describe('when there is an error executing the transaction', function () {
+      it('returns the error', function () {
+        return db.exec(function (multi) {
+          multi.set('a', 'hello');
+          multi.incr('a');
+        }).then(function (reply) {
+          expect(reply.length).toEqual(2);
+          expect(reply[1]).toEqual('ERR value is not an integer or out of range');
         });
-      }
+      });
+    });
 
-      function transaction1() {
-        var multi = db.multi();
+    describe('transactions are atomic', function () {
+      it('throws the error', function () {
+        var log = [];
 
-        return wait(10).then(function () {
-          multi.set('a', 'x');
-          return wait(10);
-        }).then(function () {
-          multi.set('b', 'y');
-          return wait(10);
-        }).then(function () {
-          multi.set('c', 'z');
-          return wait(10);
-        }).then(function () {
-          return multi.exec();
+        function wait(n) {
+          return new Promise(function (fulfil) {
+            setTimeout(fulfil, n);
+          });
+        }
+
+        function transaction1() {
+          return db.exec(function (multi) {
+            multi.set('a', 'x');
+            multi.set('b', 'y');
+            multi.set('c', 'z');
+          });
+        }
+
+        function transaction2() {
+          return db.exec(function (multi) {
+            multi.set('a', 'a');
+            multi.set('b', 'b');
+          });
+        }
+
+        function logValues() {
+          return db.mget('a', 'b', 'c').then(function (results) {
+            log.push(results);
+            if (results[2] !== 'z') {
+              return logValues();
+            }
+          });
+        }
+
+        return Promise.all([transaction1(), transaction2(), logValues()]).then(function (results) {
+          var momentsWhenAAndBAreDifferent = log.filter(function (entry) {
+            return entry[0] && entry[1] && entry[0] === entry[1];
+          });
+          expect(momentsWhenAAndBAreDifferent).toEqual([]);
+          expect(results[0]).toEqual(['OK', 'OK', 'OK']);
+          expect(results[1]).toEqual(['OK', 'OK']);
         });
-      }
-
-      function transaction2() {
-        var multi = db.multi();
-
-        return wait(10).then(function () {
-          multi.set('a', 'a');
-          return wait(10);
-        }).then(function () {
-          multi.set('b', 'b');
-          return wait(10);
-        }).then(function () {
-          return multi.exec();
-        });
-      }
-
-      function logValues() {
-        return db.mget('a', 'b', 'c').then(function (results) {
-          log.push(results);
-          if (results[2] !== 'z') {
-            return logValues();
-          }
-        });
-      }
-
-      return Promise.all([transaction1(), transaction2(), logValues()]).then(function (results) {
-        var momentsWhenAAndBAreDifferent = log.filter(function (entry) {
-          return entry[0] && entry[1] && entry[0] === entry[1];
-        });
-        expect(momentsWhenAAndBAreDifferent).toEqual([]);
-        expect(results[0]).toEqual(['OK', 'OK', 'OK']);
-        expect(results[1]).toEqual(['OK', 'OK']);
       });
     });
   });


### PR DESCRIPTION
This fixes #35.

I'm using the same technique as found in [node-redis](https://github.com/mranney/node_redis#clientmulticommands).

However, I'm trying to maintain backwards compatibility with the existing semantics of multi + exec, so I've overridden exec, which now takes a function as an argument to pipeline the commands into the multi. As in:

```
db.exec(function (multi) {
  multi.set('x', 'y');
  multi.set('a', 'b');
  ..
});
```

Which works nicely as an API for this sort of thing anyway.

BTW the original semantics are kind of broken in the concurrent case. I found I was getting `ERR MULTI calls can not be nested`, and normal commands returning `QUEUED`, all due to the fact that several "threads" (if I can use that term in Node.js) were interleaving their calls between the `multi` and the `exec` of another "thread". Anyway, not good, and only found while under a little bit of load. I wonder if it could be deprecated in favour of the above approach?
