### PR TITLE
connect to unix socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "0.10"
 before_script: 
- - redis-server /tmp/redis.sock --unixsocketperm 755
+ - redis-server --unixsocket /tmp/redis.sock --unixsocketperm 755

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
-services:
-  - redis-server
+before_script: 
+ - redis-server /tmp/redis.sock --unixsocketperm 755

--- a/tests/createclient-test.js
+++ b/tests/createclient-test.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+var redis = require('../index');
+var db = require('./db');
+
+describe('when a client is created', function () {
+  describe('with an options object', function () {
+    it('connects with expected properties', function () {
+      client = redis.createClient({ host: db.host, port: db.port, password: db.password });
+      assert.equal(client.host, db.host);
+      assert.equal(client.port, db.port);
+    });
+  });
+
+  describe('with a url string', function () {
+    it('connects with expected properties', function () {
+      client = redis.createClient('tcp://localhost:6379');
+      assert.equal(client.host, 'localhost');
+      assert.equal(client.port, 6379);
+    });
+  });
+
+  describe('with a unix socket path', function () {
+    it('connects with expected properties', function () {
+      client = redis.createClient('/tmp/redis.sock');
+      assert.equal(client.socket, '/tmp/redis.sock');
+    });
+  });
+});


### PR DESCRIPTION
#16
Connect to redis via unixsocket.

Hopefully this looks acceptable. 
In order to run `npm test` you would now need to be running your local redis-server with `--unixsocket /tmp/redis.sock --unixsocketperm 755`.

If there are any changes you'd like me to make (or any errors you spot, athough it still passes the test suite) I'm happy to patch it up accordingly.