### PR TITLE
Added additional behaviour to hscan to allow for the result to be returned as a hash

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -176,6 +176,36 @@ Object.defineProperties(Client.prototype, {
   del: d(function (keys) {
     var args = Array.isArray(keys) ? keys : slice.call(arguments, 0);
     return this.send('del', args);
+  }),
+  //Optionally allow hscan to return a hash instead of an array, provided options are provided as an object
+  hscan: d(function(key,cursor,match,matchPattern,count,countInt){
+    if(typeof match == "object"){
+      args=[key,cursor];
+      for(var k in match){
+        args.push(k,match[k]);
+      }
+      return this.send("hscan",args).then(function(result){
+        return new Promise(function(resolve,reject){
+          hash={};
+          for(i=0;i<result[1].length;i+=2){
+            hash[result[1][i]]=result[1][i+1];
+          }
+          result[1]=hash;
+          resolve(result);
+        });
+      });
+    } else if(typeof match == "string"){
+      args=[key,cursor];
+        if(match){
+          args.push(match,matchPattern);
+        }
+        if(count){
+          args.push(count,countInt);
+        }
+        return this.send("hscan",args);
+    } else{
+      return this.send("hscan",[cursor]);
+    }
   })
 
 });

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ db.hmset('my-hash', originalHash);
 db.hgetall('my-hash').then(function (hash) {
   assert.deepEqual(hash, originalHash);
 });
+db.hscan('my-hash',0,"match","*","count",2).then(function(array){
+  assert.deepEqual(array[1],['a', 'one', 'b', 'two']);
+})
+db.hscan('my-hash',0,{count:2}).then(function(array){
+  assert.deepEqual(array[1],originalHash);
+})
 
 // Transactions
 db.multi();


### PR DESCRIPTION
If the third argument for hscan is an options object, the result will be returned as a hash. Options within the object will be passed on as per usual.

To maintain backwards compatibility, directly providing options as arguments would still trigger the old behaviour, where the hash is returned as an array where {a:123,b:345} becomes ['a',123,'b',456].