### PR TITLE
bump redis to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A small, promise-based Redis client",
   "main": "index.js",
   "scripts": {
-    "test": "jshint . && mocha --reporter spec 'tests/*-test.js'"
+    "test": "jshint . && mocha --reporter spec tests/*-test.js"
   },
   "repository": {
     "type": "git",
@@ -18,10 +18,10 @@
     "expect": "^1.1.0",
     "jshint": "^2.5.10",
     "mocha": "^2.0.1",
-    "redis": "^0.12.1"
+    "redis": "^1.0.0"
   },
   "peerDependencies": {
-    "redis": "^0.12.1"
+    "redis": "^1.0.0"
   },
   "keywords": [
     "redis",

--- a/tests/connection-flag-test.js
+++ b/tests/connection-flag-test.js
@@ -1,16 +1,78 @@
 var expect = require('expect');
 var redis = require('../index');
+var net = require('net');
 
-describe('connection-flag', function () {
-  var client;
-  beforeEach(function () {
-    client = redis.createClient();
-  });
+// redis.createClient();
+// redis.createClient('tcp://localhost:6379');
+// redis.createClient(options);
+// redis.createClient(port, host, options);
+// redis.createClient();
+// redis.createClient(unix_socket, options);
+// redis.createClient('redis://user:pass@host:port', options);
 
-  it('is set on connect', function (done) {
+describe('connection', function () {
+
+  var options = {
+    host: 'localhost',
+    port: 6379,
+    password: 'password'
+  };
+
+  it('is set on connect (method #1)', function (done) {
+    var client = redis.createClient();
     client.on('connect', function () {
       expect(client.connected).toEqual(true);
       done();
     });
-  });
+  });   
+  
+  it('is set on connect (method #2)', function (done) {
+    var client = redis.createClient('tcp://localhost:6379');
+    client.on('connect', function () {
+      expect(client.connected).toEqual(true);
+      done();
+    });
+  });  
+  
+  it('is set on connect (method #3)', function (done) {
+    var client = redis.createClient(options);
+    client.on('connect', function () {
+      expect(client.connected).toEqual(true);
+      done();
+    });
+  });  
+  
+  it('is set on connect (method #4)', function (done) {
+    var client = redis.createClient(options.port, options.host, options);
+    client.on('connect', function () {
+      expect(client.connected).toEqual(true);
+      done();
+    });
+  });  
+  
+  it('is set on connect (method #5)', function (done) {
+    var client = redis.createClient();
+    client.on('connect', function () {
+      expect(client.connected).toEqual(true);
+      done();
+    });
+  });  
+  
+  it('is set on connect (method #6)', function (done) {
+    var unix_socket = net.createConnection(6379, 'localhost');
+    var client = redis.createClient(unix_socket, options);
+    client.on('connect', function () {
+      expect(client.connected).toEqual(true);
+      done();
+    });
+  });  
+  
+  it('is set on connect (method #7)', function (done) {
+    var client = redis.createClient('redis://user:pass@localhost:6379', options);
+    client.on('connect', function () {
+      expect(client.connected).toEqual(true);
+      done();
+    });
+  });  
+
 });


### PR DESCRIPTION
9 days ago, redis released `v1.0.0`, and as `then-redis` is referring to `redis` as a peerDependency, this version needs to be updated.

Tested locally, 100% pass!