### PR TITLE
update peer-dependency version to support redis 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Using [npm](https://www.npmjs.org/):
 
     $ npm install then-redis
 
+The [redis module](https://www.npmjs.com/package/redis) is a [peer dependency](https://blog.domenic.me/peer-dependencies/)
+of this module, so it will need to be installed if it hasn't been already:
+
+    $ npm install redis
+
 ### Issues
 
 Please file issues on the [issue tracker on GitHub](https://github.com/mjackson/then-redis/issues).

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "expect": "^1.1.0",
     "jshint": "^2.5.10",
     "mocha": "^2.0.1",
-    "redis": "^0.12.1"
+    "redis": "^1.0.0"
   },
   "peerDependencies": {
-    "redis": "^0.12.1"
+    "redis": ">= 0.12.1 < 2"
   },
   "keywords": [
     "redis",


### PR DESCRIPTION
This PR updates the peer-dependency version to support redis 1.0.0, which was released last week:

```
$ npm install redis

redis@1.0.0 node_modules/redis

$ npm install then-redis

npm WARN peerDependencies The peer dependency redis@^0.12.1 included from then-redis will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Linux 3.13.0-63-generic
npm ERR! argv "node" "npm" "install" "then-redis"
npm ERR! node v0.12.7
npm ERR! npm  v2.11.3
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package redis does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer then-redis@1.3.0 wants redis@^0.12.1
```