### PR TITLE
Added a options param to set the redis client. 

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -67,7 +67,7 @@ var EVENTS = [
 function Client(options) {
   EventEmitter.call(this);
 
-  redis = options.redisClient || require('redis');
+  redis = (options && options.redisClient) || require('redis');
 
   options = options || process.env.REDIS_URL || 'tcp://127.0.0.1:6379';
 

--- a/Client.js
+++ b/Client.js
@@ -66,9 +66,7 @@ var EVENTS = [
 function Client(options) {
   EventEmitter.call(this);
 
-  
   redis = options.redisClient || require('redis');
-
 
   options = options || process.env.REDIS_URL || 'tcp://127.0.0.1:6379';
 

--- a/Client.js
+++ b/Client.js
@@ -1,5 +1,5 @@
 var url = require('url');
-var redis = require('redis');
+var redis;
 var d = require('describe-property');
 var EventEmitter = require('events').EventEmitter;
 var appendHashToArray = require('./utils/appendHashToArray');
@@ -65,6 +65,10 @@ var EVENTS = [
  */
 function Client(options) {
   EventEmitter.call(this);
+
+  
+  redis = options.redisClient || require('redis');
+
 
   options = options || process.env.REDIS_URL || 'tcp://127.0.0.1:6379';
 

--- a/Client.js
+++ b/Client.js
@@ -49,6 +49,7 @@ var EVENTS = [
  * - database         The database # to use (defaults to 0)
  * - password         The password to use for AUTH
  * - returnBuffers    True to return buffers (defaults to false)
+ * - redisClient      To override the default redis client e.g. fakeredis
  *
  * Example:
  *


### PR DESCRIPTION
Using the options param { redisClient : require('ownredisclient' } can pass in which client to use. 
I'm using this currently to use https://github.com/hdachev/fakeredis for my unit tests. 

Ok, it is pretty hacky. 

Perhaps someone has a better idea?



