### PR TITLE
make redis and redis-commands regular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "readline-sync": "^1.4.1",
     "rimraf": "^2.5.2"
   },
-  "peerDependencies": {
+  "dependencies": {
     "redis": "^2.4.2",
     "redis-commands": "^1.1.0"
   },


### PR DESCRIPTION
Hi!

I noticed you've got redis and redis-commands listed as peer dependencies, but you import them directly in this module, so they should be regular dependencies.

Thanks!